### PR TITLE
V2 fix icons

### DIFF
--- a/client/nginx/default.conf
+++ b/client/nginx/default.conf
@@ -15,7 +15,7 @@ server {
     }
 
     add_header Strict-Transport-Security "max-age=31536000";
-    add_header Content-Security-Policy "default-src 'self' https://kit.fontawesome.com; connect-src 'self' https://*.fontawesome.com ; img-src 'self' data:; font-src 'self' https://ka-f.fontawesome.com https://kit.fontawesome.com fonts.gstatic.com;style-src 'self' 'sha256-lS0A3YMp01XLzFsb2kKqPUc8ywS60/0gCeQvVpUO3DY=' 'sha256-vbZVW+MEGpqM/MTrc0cuTI1eza7x/JNIBG8uVXROwnE=' 'sha256-c9m4gMlhqZ076YhLm4WUpwJSWZ3QLWlhT5327sZKH5o=' 'sha256-J9ddIaTPuLU/WoJpJUGv3stvLWJK5mWOQ70IBnw5BQk=' https://kit.fontawesome.com fonts.googleapis.com; script-src 'self' https://kit.fontawesome.com";
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data:; font-src 'self' fonts.gstatic.com;style-src 'self' fonts.googleapis.com; script-src 'self' ";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -14,7 +14,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;500;700&display=swap" rel="stylesheet">
-    <script src="https://kit.fontawesome.com/dc31bc6f6b.js" crossorigin="anonymous"></script>
     <title>531 Logger</title>
   </head>
   <body>

--- a/client/src/pages/cycles/CycleOptions.js
+++ b/client/src/pages/cycles/CycleOptions.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'
 
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 export default function CycleOptions({ repeatCycle, stepIncrement, toggleModal }) {
 

--- a/client/src/pages/cycles/FirstCycle.js
+++ b/client/src/pages/cycles/FirstCycle.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'
+
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 export default function FirstCycle({ stepIncrement, toggleModal }) {
 

--- a/client/src/pages/cycles/FormStep1.js
+++ b/client/src/pages/cycles/FormStep1.js
@@ -1,9 +1,14 @@
 import React, { Fragment } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'
 
 // Components
 import Input from '../../components/forms/Input';
+
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 export default function FormStep1({ formUtils, stepIncrement, stepDecrement, toggleModal }) {
     // Expose react form hook utils

--- a/client/src/pages/cycles/FormStep2.js
+++ b/client/src/pages/cycles/FormStep2.js
@@ -4,6 +4,11 @@ import PropTypes from 'prop-types';
 import { createCycle } from '../../actions/cycles';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'
+
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 function FormStep2({ formUtils: { getValues, handleSubmit }, formState, stepDecrement, toggleModal, createCycle, actionCompleted }) {
     // Close modal after successfully creating cycle

--- a/client/src/pages/dashboard/Dashboard.js
+++ b/client/src/pages/dashboard/Dashboard.js
@@ -5,6 +5,8 @@ import { getCycles } from '../../actions/cycles';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'
 
 // Components
 import Spinner from '../../components/layout/Spinner';
@@ -12,6 +14,9 @@ import SummaryCard from './SummaryCard';
 import CycleCard from './CycleCard';
 import CycleForm from '../cycles/CycleForm';
 import UtilityButton from '../../components/buttons/UtilityButton';
+
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 const Dashboard = ({
   auth: { loading: authLoading, user },

--- a/client/src/pages/landing/Landing.js
+++ b/client/src/pages/landing/Landing.js
@@ -1,14 +1,19 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
+import { config } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import '@fortawesome/fontawesome-svg-core/styles.css'
+
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 const Landing = () => {
   return (
     <Fragment>
       <section className="container-landing">
         <div className="landing-items container-flex container-vertical container-vertical-center bg-primary">
-            <FontAwesomeIcon className="logo" icon={solid('dumbbell')} size="8x" />
+            <FontAwesomeIcon className="logo" icon={solid('dumbbell')} size='8x' />
             <h1 className="app-name text text-large">
               More Plates
             </h1>

--- a/client/src/pages/workouts/Workout.js
+++ b/client/src/pages/workouts/Workout.js
@@ -9,6 +9,11 @@ import SetCard from './SetCard';
 import SummaryCard from '../../pages/dashboard/SummaryCard';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'
+
+// Prevent fontawesome from adding css to the head
+config.autoAddCss = false;
 
 const capitalize = (string) => {
   return string[0].toUpperCase()+string.slice(1);


### PR DESCRIPTION
Components needs to manually add css as CSP blocks fontawesome from adding css.
CSP has been updated to remove whitelisted sha hashes for webfont fontawesome icons
Fontawesome script removed from html head.

This completes the transition from webfonts fontawesome to react fontawesome component with SVGs